### PR TITLE
docs: 스웨거와의 호환성을 위해 스프링 버전을 3.3.8로 낮춤

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
+	id 'org.springframework.boot' version '3.3.8'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -33,7 +33,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.google.cloud:spring-cloud-gcp-storage:5.8.0'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/src/main/java/moadong/club/controller/ClubController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubController.java
@@ -48,12 +48,14 @@ public class ClubController {
     }
 
     @GetMapping("/{clubId}")
+    @Operation(summary = "클럽 상세 정보 조회", description = "클럽 상세 정보를 조회합니다.")
     public ResponseEntity<?> getClubDetailedPage(@PathVariable String clubId) {
         ClubDetailedPageResponse clubDetailedPageResponse = clubDetailedPageService.getClubDetailedPage(clubId);
         return Response.ok(clubDetailedPageResponse);
     }
 
     @GetMapping("/list/")
+    @Operation(summary = "클럽 리스트 조회(모집,분과,종류에 따른 구분)", description = "모집,분과,종류에 따른 구분에 따라 클럽 리스트 조회합니다.")
     public ResponseEntity<?> getClubsByFilter(
             @RequestParam(value = "availability", required = false) String availability,
             @RequestParam(value = "classification", required = false) String classification,
@@ -64,6 +66,7 @@ public class ClubController {
     }
 
     @GetMapping("/search/")
+    @Operation(summary = "키워드에 맞는 클럽을 검색합니다.", description = "이름,태그,소개에 따라 검색합니다.")
     public ResponseEntity<?> searchClubsByKeyword(
             @RequestParam(value = "keyword", required = true) String keyword
     ){

--- a/backend/src/main/java/moadong/gcs/controller/ClubImageController.java
+++ b/backend/src/main/java/moadong/gcs/controller/ClubImageController.java
@@ -1,6 +1,9 @@
 package moadong.gcs.controller;
 
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import moadong.gcs.dto.ImageDeleteRequest;
 import moadong.gcs.service.ClubImageService;
@@ -18,12 +21,14 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/club")
 @RequiredArgsConstructor
+@Tag(name = "ClubImage", description = "클럽 이미지 관련 API")
 public class ClubImageController {
 
     private final ClubImageService clubImageService;
 
 
     @PostMapping("/{clubId}/logo")
+    @Operation(summary = "로고 이미지 업로드", description = "로고 이미지를 저장소에 업로드합니다.")
     public ResponseEntity<?> uploadLogo(@PathVariable String clubId,
                                         @RequestParam("logo") MultipartFile file) {
         String fileUrl = clubImageService.uploadLogo(clubId, file);
@@ -31,12 +36,14 @@ public class ClubImageController {
     }
 
     @DeleteMapping("/images")
+    @Operation(summary = "동아리 이미지 삭제", description = "저장소에 있는 동아리 이미지를 삭제합니다.")
     public ResponseEntity<?> deleteFile(@RequestBody ImageDeleteRequest imageDeleteRequest) {
         clubImageService.deleteFile(imageDeleteRequest.filePath());
         return Response.ok("success delete image");
     }
 
     @PostMapping("/{clubId}/feeds")
+    @Operation(summary = "피드 이미지 업로드", description = "피드 이미지를 저장소에 업로드합니다.")
     public ResponseEntity<?> uploadLogo(@PathVariable String clubId,
                                         @RequestParam("feeds") List<MultipartFile> files) {
         clubImageService.uploadFeeds(clubId, files);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #47 

## 📝작업 내용
- spring 3.4.1에서 swagger사용시 @ConrollerAdvice를 사용할 수 없는 문제를 해결하기 위해 스프링 버전을 3.4.1 -> 3.3.8로 낮추었습니다.
  - [참고 : [트러블슈팅] HY-THON - Swagger 500 에러: Failed to load API definition](https://dev-meung.tistory.com/entry/%ED%95%B4%EC%BB%A4%ED%86%A4-HY-THON-%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85-Swagger-500-%EC%97%90%EB%9F%AC-Failed-to-load-API-definition)
- 스웨거 버전도 2.3.0으로 향상하였습니다.
- 컨트롤러에 대해 swagger 설명을 추가하였습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

## 참고사항