### PR TITLE
[refactor] 상세페이지 조회 response 수정

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import moadong.club.payload.request.ClubCreateRequest;
 import moadong.club.payload.request.ClubUpdateRequest;
-import moadong.club.payload.response.ClubDetailedPageResponse;
+import moadong.club.payload.response.ClubDetailedResponse;
 import moadong.club.payload.response.ClubSearchResponse;
 import moadong.club.service.ClubCommandService;
 import moadong.club.service.ClubDetailedPageService;
@@ -50,7 +50,7 @@ public class ClubController {
     @GetMapping("/{clubId}")
     @Operation(summary = "클럽 상세 정보 조회", description = "클럽 상세 정보를 조회합니다.")
     public ResponseEntity<?> getClubDetailedPage(@PathVariable String clubId) {
-        ClubDetailedPageResponse clubDetailedPageResponse = clubDetailedPageService.getClubDetailedPage(clubId);
+        ClubDetailedResponse clubDetailedPageResponse = clubDetailedPageService.getClubDetailedPage(clubId);
         return Response.ok(clubDetailedPageResponse);
     }
 

--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -1,32 +1,33 @@
-package moadong.club.payload.response;
+package moadong.club.payload.dto;
 
 import lombok.Builder;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubInformation;
+import moadong.club.payload.response.ClubDetailedResponse;
 
 import java.util.List;
 
 @Builder
-public record ClubDetailedPageResponse(
-        String id,
-        String name,
-        String logo,
-        List<String> tags,
-        String state,
-        List<String> feeds,
-        String description,
-        String presidentName,
-        String presidentPhoneNumber,
-        String recruitmentPeriod,
-        String classification,
-        String division
-) {
-    public static ClubDetailedPageResponse createClubDetailedPageResponse(
+public record ClubDetailedResult(
+    String id,
+    String name,
+    String logo,
+    List<String> tags,
+    String state,
+    List<String> feeds,
+    String description,
+    String presidentName,
+    String presidentPhoneNumber,
+    String recruitmentPeriod,
+    String classification,
+    String division
+){
+    public static ClubDetailedResult of(
             Club club,
             ClubInformation clubInformation,
             List<String> clubFeedImages,
             List<String> clubTags) {
-        return ClubDetailedPageResponse.builder()
+        return ClubDetailedResult.builder()
                 .id(club.getId())
                 .name(club.getName())
                 .classification(club.getClassification())
@@ -39,4 +40,5 @@ public record ClubDetailedPageResponse(
                 .tags(clubTags)
                 .build();
     }
+
 }

--- a/backend/src/main/java/moadong/club/payload/response/ClubDetailedPageResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubDetailedPageResponse.java
@@ -8,27 +8,35 @@ import java.util.List;
 
 @Builder
 public record ClubDetailedPageResponse(
-        String clubId,
-        String clubName,
-        String clubImageUrl,
-        List<String> clubTags,
-        String clubState,
-        List<String> clubFeeds,
-        String clubDescription,
-        String clubPresidentName,
-        String clubPresidentPhoneNumber,
-        String clubPeriod
+        String id,
+        String name,
+        String logo,
+        List<String> tags,
+        String state,
+        List<String> feeds,
+        String description,
+        String presidentName,
+        String presidentPhoneNumber,
+        String recruitmentPeriod,
+        String classification,
+        String division
 ) {
-    public static ClubDetailedPageResponse createClubDetailedPageResponse(Club club, ClubInformation clubInformation, List<String> clubFeedImages, List<String> clubTags) {
+    public static ClubDetailedPageResponse createClubDetailedPageResponse(
+            Club club,
+            ClubInformation clubInformation,
+            List<String> clubFeedImages,
+            List<String> clubTags) {
         return ClubDetailedPageResponse.builder()
-                .clubId(club.getId())
-                .clubName(club.getName())
-                .clubState(club.getState().getDesc())
-                .clubDescription(clubInformation.getDescription())
-                .clubPresidentName(clubInformation.getPresidentName())
-                .clubPresidentPhoneNumber(clubInformation.getPresidentTelephoneNumber())
-                .clubFeeds(clubFeedImages)
-                .clubTags(clubTags)
+                .id(club.getId())
+                .name(club.getName())
+                .classification(club.getClassification())
+                .division(club.getDivision())
+                .state(club.getState().getDesc())
+                .description(clubInformation.getDescription())
+                .presidentName(clubInformation.getPresidentName())
+                .presidentPhoneNumber(clubInformation.getPresidentTelephoneNumber())
+                .feeds(clubFeedImages)
+                .tags(clubTags)
                 .build();
     }
 }

--- a/backend/src/main/java/moadong/club/payload/response/ClubDetailedResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubDetailedResponse.java
@@ -1,0 +1,10 @@
+package moadong.club.payload.response;
+
+import lombok.Builder;
+import moadong.club.payload.dto.ClubDetailedResult;
+
+@Builder
+public record ClubDetailedResponse(
+    ClubDetailedResult club
+) {
+}

--- a/backend/src/main/java/moadong/club/service/ClubDetailedPageService.java
+++ b/backend/src/main/java/moadong/club/service/ClubDetailedPageService.java
@@ -3,9 +3,10 @@ package moadong.club.service;
 import lombok.AllArgsConstructor;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubInformation;
+import moadong.club.payload.dto.ClubDetailedResult;
 import moadong.club.payload.dto.ClubFeedImageProjection;
 import moadong.club.payload.dto.ClubTagProjection;
-import moadong.club.payload.response.ClubDetailedPageResponse;
+import moadong.club.payload.response.ClubDetailedResponse;
 import moadong.club.repository.ClubFeedImageRepository;
 import moadong.club.repository.ClubInformationRepository;
 import moadong.club.repository.ClubRepository;
@@ -27,7 +28,7 @@ public class ClubDetailedPageService {
     private final ClubFeedImageRepository clubFeedImageRepository;
     private final ClubTagRepository clubTagRepository;
 
-    public ClubDetailedPageResponse getClubDetailedPage(String clubId) {
+    public ClubDetailedResponse getClubDetailedPage(String clubId) {
         ObjectId objectId = new ObjectId(clubId);
         Club club = clubRepository.findClubById(objectId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
@@ -45,12 +46,13 @@ public class ClubDetailedPageService {
                 .stream()
                 .map(ClubTagProjection::getTag)
                 .toList();
-
-        return ClubDetailedPageResponse.createClubDetailedPageResponse(
+        
+        ClubDetailedResult clubDetailedResult = ClubDetailedResult.of(
                 club,
                 clubInformation,
                 clubFeedImages,
                 clubTags
         );
+        return new ClubDetailedResponse(clubDetailedResult);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#53 

## 📝작업 내용

- 기존에 만들어진 상세페이지 조회 관련 api 명세서를 전체 목록 조회와 필드를 일치하기 수정
- 분과와 종류 추가

결과값
![image](https://github.com/user-attachments/assets/b0e2c215-4727-493d-828c-d92ded36da2e)


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항