### PR TITLE
[feature] 상세 페이지: 프로필 및 지원하기 버튼 컴포넌트 추가

### DIFF
--- a/frontend/src/components/ClubLogo/ClubLogo.tsx
+++ b/frontend/src/components/ClubLogo/ClubLogo.tsx
@@ -1,32 +1,46 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-const logoSizes = {
-  small: { imageSize: '45px' },
-  large: { imageSize: '100px' },
-};
+type LogoVariant = 'main' | 'detail';
 
-type LogoSizeKeys = keyof typeof logoSizes;
-
-interface ClubProfileProps {
+interface ClubLogoProps {
   imageSrc?: string;
-  logoSize?: LogoSizeKeys;
+  variant?: LogoVariant;
 }
 
-const StyledClubLogo = styled.div<{ size: LogoSizeKeys; imageSrc?: string }>`
-  ${({ size, imageSrc }) => css`
-    width: ${logoSizes[size].imageSize};
-    height: ${logoSizes[size].imageSize};
+const presets = {
+  main: {
+    desktop: { width: '45px', height: '45px', radius: '6px' },
+    mobile: { width: '36px', height: '35px', radius: '6px' },
+  },
+  detail: {
+    desktop: { width: '80px', height: '80px', radius: '10px' },
+    mobile: { width: '50px', height: '50px', radius: '6px' },
+  },
+};
+
+const StyledClubLogo = styled.div<{ variant: LogoVariant; imageSrc?: string }>`
+  ${({ variant, imageSrc }) => css`
+    width: ${presets[variant].desktop.width};
+    height: ${presets[variant].desktop.height};
+    border-radius: ${presets[variant].desktop.radius};
     background-color: #efefef;
-    border-radius: 10px;
     background-size: cover;
     background-position: center;
     background-image: ${imageSrc ? `url(${imageSrc})` : 'none'};
   `}
+
+  @media (max-width: 480px) {
+    ${({ variant }) => css`
+      width: ${presets[variant].mobile.width};
+      height: ${presets[variant].mobile.height};
+      border-radius: ${presets[variant].mobile.radius};
+    `}
+  }
 `;
 
-const ClubLogo = ({ imageSrc, logoSize = 'small' }: ClubProfileProps) => {
-  return <StyledClubLogo imageSrc={imageSrc} size={logoSize} />;
+const ClubLogo = ({ imageSrc, variant = 'main' }: ClubLogoProps) => {
+  return <StyledClubLogo imageSrc={imageSrc} variant={variant} />;
 };
 
 export default ClubLogo;

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface ButtonProps {
+  onClick?: () => void;
+}
+
+const Button = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out;
+
+  background-color: #3a3a3a;
+  color: white;
+  font-weight: bold;
+
+  width: 148px;
+  height: 44px;
+  font-size: 1.25rem;
+
+  &:hover {
+    background-color: #555;
+    transform: scale(1.03);
+  }
+
+  @media (max-width: 480px) {
+    width: 256px;
+    height: 44px;
+    font-size: 1rem;
+  }
+`;
+
+const ClubApplyButton = ({ onClick }: ButtonProps) => {
+  return <Button onClick={onClick}>지원하기</Button>;
+};
+
+export default ClubApplyButton;

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfile/ClubProfile.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfile/ClubProfile.styles.ts
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+const ClubContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 21px;
+
+  @media (max-width: 480px) {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto auto;
+    grid-template-areas:
+      'logo name'
+      'tags tags';
+    gap: 12px;
+  }
+`;
+
+const ClubInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: auto;
+
+  @media (max-width: 480px) {
+    display: contents;
+  }
+`;
+
+const ClubName = styled.p`
+  font-size: 2.375rem;
+  font-weight: bold;
+  color: #000;
+
+  @media (max-width: 480px) {
+    font-size: 1.875rem;
+    grid-area: name;
+  }
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+
+  @media (max-width: 480px) {
+    gap: 6px;
+    grid-area: tags;
+  }
+`;
+
+export { ClubContainer, ClubInfo, ClubName, TagContainer };

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfile/ClubProfile.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfile/ClubProfile.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import ClubLogo from '@/components/ClubLogo/ClubLogo';
+import ClubTag from '@/components/ClubTag/ClubTag';
+import * as Styled from './ClubProfile.styles';
+
+interface ClubProfileProps {
+  logo?: string;
+  name: string;
+  classification: string; // 클럽 분류 (예: "중동")
+  division: string; // 클럽 분과 (예: "학술")
+  tags?: string[];
+}
+
+const ClubProfile = ({
+  logo,
+  name,
+  classification,
+  division,
+  tags = [],
+}: ClubProfileProps) => {
+  return (
+    <Styled.ClubContainer>
+      <ClubLogo variant='detail' imageSrc={logo} />
+      <Styled.ClubInfo>
+        <Styled.ClubName>{name}</Styled.ClubName>
+        <Styled.TagContainer>
+          <ClubTag type={classification}>{classification}</ClubTag>
+          <ClubTag type={division}>{division}</ClubTag>
+          {tags.map((tag) => (
+            <ClubTag key={tag} type='자유'>
+              {tag}
+            </ClubTag>
+          ))}
+        </Styled.TagContainer>
+      </Styled.ClubInfo>
+    </Styled.ClubContainer>
+  );
+};
+
+export default ClubProfile;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #48

## 📝작업 내용

### 1. 동아리 프로필 컴포넌트 만들기(ClubProfile.tsx)
로고 이미지, 이름, 분류, 분과, 태그들을 Props로 받음

- 살면서 짜본 CSS중 제일 어려웠으나 다행히 성공
- 결과물은 별거 아닌 것 같지만.....진짜 갈아넣었네욤😭



[데스크탑]
![image](https://github.com/user-attachments/assets/62ebde6b-e76e-465e-b09a-d638be0bebe7)

[모바일]
![image](https://github.com/user-attachments/assets/04cd2f6e-78cd-44ec-80c0-3589ca19dde4)

<br />


### 2. 동아리 지원하기 버튼 컴포넌트 만들기
onClick()을 Props로 받음
[데스크탑]
![image](https://github.com/user-attachments/assets/2d9a64f5-9419-4bc7-bea6-c4c0d617535e)


[모바일]
![image](https://github.com/user-attachments/assets/cdd62593-1631-47e6-824f-f1552665ae47)

<br />

### 작동 영상

https://github.com/user-attachments/assets/b0537b87-4c38-47b1-861c-beed5c73c3bc

<br />


## 중점적으로 리뷰받고 싶은 부분(선택)
혹시 놓친 부분이나 개선할 점이 있다면 피드백 부탁드립니다.


## 논의하고 싶은 부분(선택)
이거 지원하기 버튼 모바일 버전이랑 구분해서 만들긴했는데 이거 어캐 배치할까용?
따로 만들어야할 것 같기도 하고요

## 🫡 참고사항