### PR TITLE
[feature] 모집정보 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubInformation.java
+++ b/backend/src/main/java/moadong/club/entity/ClubInformation.java
@@ -50,6 +50,8 @@ public class ClubInformation {
 
     private LocalDateTime recruitmentEnd;
 
+    private String recruitmentTarget;
+
     @Enumerated(EnumType.STRING)
     @NotNull
     private RecruitmentStatus recruitmentStatus;
@@ -62,6 +64,7 @@ public class ClubInformation {
         this.presidentTelephoneNumber = request.telephoneNumber();
         this.recruitmentStart = request.recruitmentStart();
         this.recruitmentEnd = request.recruitmentEnd();
+        this.recruitmentTarget = request.recruitmentTarget();
         this.recruitmentStatus = RecruitmentStatus.UPCOMING;
     }
 

--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -1,11 +1,10 @@
 package moadong.club.payload.dto;
 
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import lombok.Builder;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubInformation;
-import moadong.club.payload.response.ClubDetailedResponse;
-
-import java.util.List;
 
 @Builder
 public record ClubDetailedResult(
@@ -19,26 +18,32 @@ public record ClubDetailedResult(
     String presidentName,
     String presidentPhoneNumber,
     String recruitmentPeriod,
+    String recruitmentTarget,
     String classification,
     String division
-){
+) {
+
     public static ClubDetailedResult of(
-            Club club,
-            ClubInformation clubInformation,
-            List<String> clubFeedImages,
-            List<String> clubTags) {
+        Club club,
+        ClubInformation clubInformation,
+        List<String> clubFeedImages,
+        List<String> clubTags) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
         return ClubDetailedResult.builder()
-                .id(club.getId())
-                .name(club.getName())
-                .classification(club.getClassification())
-                .division(club.getDivision())
-                .state(club.getState().getDesc())
-                .description(clubInformation.getDescription())
-                .presidentName(clubInformation.getPresidentName())
-                .presidentPhoneNumber(clubInformation.getPresidentTelephoneNumber())
-                .feeds(clubFeedImages)
-                .tags(clubTags)
-                .build();
+            .id(club.getId())
+            .name(club.getName())
+            .classification(club.getClassification())
+            .division(club.getDivision())
+            .state(club.getState().getDesc())
+            .description(clubInformation.getDescription())
+            .presidentName(clubInformation.getPresidentName())
+            .presidentPhoneNumber(clubInformation.getPresidentTelephoneNumber())
+            .feeds(clubFeedImages)
+            .tags(clubTags)
+            .recruitmentPeriod(clubInformation.getRecruitmentStart().format(formatter) + " ~ "
+                + clubInformation.getRecruitmentEnd().format(formatter))
+            .recruitmentTarget(clubInformation.getRecruitmentTarget())
+            .build();
     }
 
 }

--- a/backend/src/main/java/moadong/club/payload/request/ClubUpdateRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubUpdateRequest.java
@@ -15,7 +15,8 @@ public record ClubUpdateRequest(
     String clubPresidentName,
     String telephoneNumber,
     LocalDateTime recruitmentStart,
-    LocalDateTime recruitmentEnd
+    LocalDateTime recruitmentEnd,
+    String recruitmentTarget
 ) {
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #84 

## 📝작업 내용
### erd 수정
erd cloud의 erd를 아래와 같이 수정하였습니다.
![image](https://github.com/user-attachments/assets/737d9ef2-b812-4013-8dbe-7e823a5f2af0)
  
### **변경된 명세**
api 변경사항을 명세서에 반영하였습니다.
https://www.notion.so/c2068f8c4e6e459aa017ed62e2a75abe
- **statusCode** (String) → ✅ 그대로 유지 (`statuscode` → `statusCode`로 변경 가능)
- **message** (String) → ✅ 그대로 유지
- **data** (Object) → ✅ 그대로 유지
    - **club** (Object) → ✅ `clubId`, `clubName`, `clubImageUrl` 등을 `club` 객체 안으로 이동
        - **id** (String) → 🔄 기존 `clubId`에 해당
        - **name** (String) → 🔄 기존 `clubName`에 해당
        - **logo** (String) → 🔄 기존 `clubImageUrl`에 해당 (`null` 가능)
        - **tags** (List<String>) → ✅ 기존 `clubTags`와 동일
        - **state** (String) → 🔄 기존 `clubState`
            - 기존에는 `"모집 중"`, `"모집 마감"`, `"모집 예정"`이었는데,새로운 응답에서는 `"활성화"` 등의 표현 사용
        - **feeds** (List<String>) → ✅ 기존 `clubFeeds`와 동일
        - **description** (String) → 🔄 기존 `소개 글`
        - **presidentName** (String) → 🔄 기존 `president`
        - **presidentPhoneNumber** (String) → 🔄 기존 `phone`
        - **recruitmentPeriod** (String) → ✅ 기존 `period`와 동일한 형태 (`yyyy.MM.dd HH:mm ~ yyyy.MM.dd HH:mm`)
        - **recruitmentTarget** (String, nullable) → 🆕 새로운 필드 (기존 명세에는 없음)
        - **classification** (String) → 🆕 새로운 필드 (기존 명세에는 없음)
        - **division** (String) → 🆕 새로운 필드 (기존 명세에는 없음)

### 코드
- 엔티티 및 DTO 변경
- 모집시기에 대한 데이터 제공

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

## 🫡 참고사항